### PR TITLE
fix: use LegacyAny in wasm v4->v5 migration to avoid gogoproto panic

### DIFF
--- a/x/wasm/migrations/v4_xion/legacy_types.go
+++ b/x/wasm/migrations/v4_xion/legacy_types.go
@@ -1,22 +1,35 @@
 package v4
 
 import (
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/gogoproto/proto"
 )
 
 // LegacyContractInfo represents the ContractInfo structure from wasmd v0.61.2
 // where ibc2_port_id was at field 7 and extension was at field 8.
 // This is the INCORRECT field order that was fixed in v0.61.5+ (commit 6cbaaae4).
+//
+// IMPORTANT: We use *LegacyAny instead of *codectypes.Any for the Extension field
+// because codectypes.Any has an unexported cachedValue field without a protobuf tag.
+// Since LegacyContractInfo is a hand-written type (no generated XXX_Unmarshal),
+// gogoproto falls back to its table-driven unmarshaler which panics on
+// "protobuf tag not enough fields in Any.cachedValue".
 type LegacyContractInfo struct {
-	CodeID      uint64                 `protobuf:"varint,1,opt,name=code_id,json=codeId,proto3" json:"code_id,omitempty"`
-	Creator     string                 `protobuf:"bytes,2,opt,name=creator,proto3" json:"creator,omitempty"`
-	Admin       string                 `protobuf:"bytes,3,opt,name=admin,proto3" json:"admin,omitempty"`
-	Label       string                 `protobuf:"bytes,4,opt,name=label,proto3" json:"label,omitempty"`
-	Created     *AbsoluteTxPosition    `protobuf:"bytes,5,opt,name=created,proto3" json:"created,omitempty"`
-	IBCPortID   string                 `protobuf:"bytes,6,opt,name=ibc_port_id,json=ibcPortId,proto3" json:"ibc_port_id,omitempty"`
-	IBC2PortID  string                 `protobuf:"bytes,7,opt,name=ibc2_port_id,json=ibc2PortId,proto3" json:"ibc2_port_id,omitempty"` // OLD: field 7
-	Extension   *codectypes.Any        `protobuf:"bytes,8,opt,name=extension,proto3" json:"extension,omitempty"`                        // OLD: field 8
+	CodeID     uint64              `protobuf:"varint,1,opt,name=code_id,json=codeId,proto3" json:"code_id,omitempty"`
+	Creator    string              `protobuf:"bytes,2,opt,name=creator,proto3" json:"creator,omitempty"`
+	Admin      string              `protobuf:"bytes,3,opt,name=admin,proto3" json:"admin,omitempty"`
+	Label      string              `protobuf:"bytes,4,opt,name=label,proto3" json:"label,omitempty"`
+	Created    *AbsoluteTxPosition `protobuf:"bytes,5,opt,name=created,proto3" json:"created,omitempty"`
+	IBCPortID  string              `protobuf:"bytes,6,opt,name=ibc_port_id,json=ibcPortId,proto3" json:"ibc_port_id,omitempty"`
+	IBC2PortID string              `protobuf:"bytes,7,opt,name=ibc2_port_id,json=ibc2PortId,proto3" json:"ibc2_port_id,omitempty"` // OLD: field 7
+	Extension  *LegacyAny          `protobuf:"bytes,8,opt,name=extension,proto3" json:"extension,omitempty"`                       // OLD: field 8
+}
+
+// LegacyAny is a minimal replacement for codectypes.Any that only contains
+// protobuf-tagged fields. This avoids the gogoproto table-driven unmarshaler
+// panic caused by codectypes.Any's unexported cachedValue field.
+type LegacyAny struct {
+	TypeUrl string `protobuf:"bytes,1,opt,name=type_url,json=typeUrl,proto3" json:"type_url,omitempty"`
+	Value   []byte `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 }
 
 // AbsoluteTxPosition is a unique transaction position that allows for global ordering of transactions.
@@ -28,6 +41,10 @@ type AbsoluteTxPosition struct {
 func (m *LegacyContractInfo) Reset()         { *m = LegacyContractInfo{} }
 func (m *LegacyContractInfo) String() string { return proto.CompactTextString(m) }
 func (*LegacyContractInfo) ProtoMessage()    {}
+
+func (m *LegacyAny) Reset()         { *m = LegacyAny{} }
+func (m *LegacyAny) String() string { return proto.CompactTextString(m) }
+func (*LegacyAny) ProtoMessage()    {}
 
 func (m *AbsoluteTxPosition) Reset()         { *m = AbsoluteTxPosition{} }
 func (m *AbsoluteTxPosition) String() string { return proto.CompactTextString(m) }

--- a/x/wasm/migrations/v4_xion/legacy_types_test.go
+++ b/x/wasm/migrations/v4_xion/legacy_types_test.go
@@ -1,0 +1,104 @@
+package v4
+
+import (
+	"testing"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLegacyContractInfoUnmarshalWithExtension verifies that unmarshaling a
+// LegacyContractInfo with a non-nil Extension field does NOT panic.
+//
+// This was the root cause of the v28 upgrade failure:
+// codectypes.Any has an unexported cachedValue field without a protobuf tag.
+// When gogoproto's table-driven unmarshaler encounters it, it panics with
+// "protobuf tag not enough fields in Any.cachedValue".
+//
+// The fix uses LegacyAny (which only has tagged fields) instead of codectypes.Any.
+func TestLegacyContractInfoUnmarshalWithExtension(t *testing.T) {
+	// Build a LegacyContractInfo with Extension populated (field 8 in legacy schema)
+	original := &LegacyContractInfo{
+		CodeID:     42,
+		Creator:    "xion1creator",
+		Admin:      "xion1admin",
+		Label:      "my-contract",
+		IBCPortID:  "wasm.xion1port",
+		IBC2PortID: "wasm.xion1ibc2port",
+		Created: &AbsoluteTxPosition{
+			BlockHeight: 100,
+			TxIndex:     5,
+		},
+		Extension: &LegacyAny{
+			TypeUrl: "/xion.v1.ContractExtension",
+			Value:   []byte{0x0a, 0x04, 0x74, 0x65, 0x73, 0x74}, // some protobuf bytes
+		},
+	}
+
+	// Marshal it
+	bz, err := proto.Marshal(original)
+	require.NoError(t, err)
+
+	// Unmarshal - this used to panic with codectypes.Any
+	var decoded LegacyContractInfo
+	assert.NotPanics(t, func() {
+		err = proto.Unmarshal(bz, &decoded)
+	}, "unmarshaling LegacyContractInfo with Extension should not panic")
+	require.NoError(t, err)
+
+	// Verify fields round-tripped correctly
+	assert.Equal(t, original.CodeID, decoded.CodeID)
+	assert.Equal(t, original.Creator, decoded.Creator)
+	assert.Equal(t, original.Admin, decoded.Admin)
+	assert.Equal(t, original.Label, decoded.Label)
+	assert.Equal(t, original.IBCPortID, decoded.IBCPortID)
+	assert.Equal(t, original.IBC2PortID, decoded.IBC2PortID)
+	assert.Equal(t, original.Created.BlockHeight, decoded.Created.BlockHeight)
+	assert.Equal(t, original.Created.TxIndex, decoded.Created.TxIndex)
+	require.NotNil(t, decoded.Extension)
+	assert.Equal(t, original.Extension.TypeUrl, decoded.Extension.TypeUrl)
+	assert.Equal(t, original.Extension.Value, decoded.Extension.Value)
+}
+
+// TestLegacyAnyToCodecTypesAny verifies conversion from LegacyAny to codectypes.Any.
+func TestLegacyAnyToCodecTypesAny(t *testing.T) {
+	legacy := &LegacyAny{
+		TypeUrl: "/xion.v1.SomeType",
+		Value:   []byte{0x01, 0x02, 0x03},
+	}
+
+	converted := &codectypes.Any{
+		TypeUrl: legacy.TypeUrl,
+		Value:   legacy.Value,
+	}
+
+	assert.Equal(t, legacy.TypeUrl, converted.TypeUrl)
+	assert.Equal(t, legacy.Value, converted.Value)
+}
+
+// TestLegacyContractInfoUnmarshalWithoutExtension verifies that contracts
+// without an Extension field still unmarshal correctly.
+func TestLegacyContractInfoUnmarshalWithoutExtension(t *testing.T) {
+	original := &LegacyContractInfo{
+		CodeID:     1,
+		Creator:    "xion1creator",
+		Label:      "simple-contract",
+		IBC2PortID: "",
+	}
+
+	bz, err := proto.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded LegacyContractInfo
+	assert.NotPanics(t, func() {
+		err = proto.Unmarshal(bz, &decoded)
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, original.CodeID, decoded.CodeID)
+	assert.Equal(t, original.Creator, decoded.Creator)
+	assert.Equal(t, original.Label, decoded.Label)
+	assert.Nil(t, decoded.Extension)
+}

--- a/x/wasm/migrations/v4_xion/store.go
+++ b/x/wasm/migrations/v4_xion/store.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/store/prefix"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -85,7 +86,10 @@ func (m Migrator) Migrate4to5(ctx sdk.Context, storeService corestoretypes.KVSto
 
 		// Copy Extension field - moved from field 8 to field 7
 		if legacyInfo.Extension != nil {
-			newInfo.Extension = legacyInfo.Extension
+			newInfo.Extension = &codectypes.Any{
+				TypeUrl: legacyInfo.Extension.TypeUrl,
+				Value:   legacyInfo.Extension.Value,
+			}
 		}
 
 		// Store with NEW schema


### PR DESCRIPTION
Fixes the v28 testnet upgrade panic: protobuf tag not enough fields in Any.cachedValue. Replace codectypes.Any with LegacyAny containing only properly tagged fields.