### PR TITLE
Release/v0.61.x

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
   setup-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Restore Go modules cache
         uses: actions/cache@v4
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-dependencies
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Check go mod tidy
         run: |
           go mod tidy
@@ -51,11 +51,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-dependencies
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.6
+          version: v2.11.4
           args: --tests=false --timeout=5m0s
 
   test-cover:
@@ -65,7 +65,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Restore Go modules cache
         uses: actions/cache@v4
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-cover
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v6
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-cover
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Restore Go modules cache
         uses: actions/cache@v4
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-cover
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Restore Go modules cache
         uses: actions/cache@v4
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-dependencies
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Run simulations
         run: make test-sim-deterministic test-sim-multi-seed-short test-sim-import-export
@@ -182,7 +182,7 @@ jobs:
     env:
       IMAGE_NAME: cosmwasm/wasmd
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/codeql-analizer.yml
+++ b/.github/workflows/codeql-analizer.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -33,4 +33,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
-

--- a/.github/workflows/proto-buf-linter.yml
+++ b/.github/workflows/proto-buf-linter.yml
@@ -13,7 +13,7 @@ jobs:
   buf-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-setup-action@v1.47.2
 
       # lint checks

--- a/.github/workflows/proto-buf-publisher.yml
+++ b/.github/workflows/proto-buf-publisher.yml
@@ -16,7 +16,7 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-setup-action@v1.47.2
 
       # lint checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/typo-check.yml
+++ b/.github/workflows/typo-check.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
       - name: Run spell-check
         uses: crate-ci/typos@master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a fork of [CosmWasm/wasmd](https://github.com/CosmWasm/wasmd), a Cosmos SDK blockchain with CosmWasm smart contract support. The fork is maintained by Burnt (Xion) with custom modifications aligned to the Xion chain. The primary module is `x/wasm`, which integrates WebAssembly smart contract execution via [wasmvm](https://github.com/CosmWasm/wasmvm).
+
+**Go 1.24+ required.** Module path: `github.com/CosmWasm/wasmd`
+
+## Build & Test Commands
+
+```bash
+# Build binary to ./build/wasmd
+make build
+
+# Install to $GOPATH/bin
+make install
+
+# Run all unit tests
+make test
+
+# Run a single test
+go test -mod=readonly -tags='ledger test_ledger_mock' -run TestFunctionName ./x/wasm/keeper/...
+
+# Run tests with race detection
+make test-race
+
+# Run tests with coverage
+make test-cover
+
+# Run system/integration tests (requires install first)
+make test-system
+
+# Lint (requires golangci-lint)
+make lint
+
+# Format code (installs gofumpt, misspell, gci)
+make format
+
+# Protobuf generation (requires Docker)
+make proto-gen
+```
+
+## Architecture
+
+### Core Module: `x/wasm`
+
+The entire wasm module lives under `x/wasm/` following Cosmos SDK module conventions:
+
+- **`keeper/`** — State machine logic. `Keeper` manages contract lifecycle (upload, instantiate, execute, migrate, sudo). `ContractKeeper` wraps Keeper with permission checks. `handler_plugin.go` and `handler_plugin_encoders.go` handle dispatching CosmWasm messages to SDK messages.
+- **`types/`** — All protobuf-generated types, message definitions, params, keys, errors, and keeper interfaces (`ViewKeeper`, `ContractOpsKeeper`). Protobuf sources are in `proto/cosmwasm/wasm/v1/`.
+- **`keeper/query_plugins.go`** — Custom querier plugins that bridge CosmWasm queries to SDK queries (bank, staking, distribution, IBC, etc.).
+- **`keeper/msg_dispatcher.go`** — Dispatches sub-messages from contract execution, handling reply logic.
+- **`keeper/ibc.go` / `ibc2.go`** — IBC integration for wasm contracts (ICS-20, ICS-27, IBC v2).
+- **`migrations/`** — State migration handlers for module version upgrades (v1, v2, v3).
+- **`module.go`** — AppModule registration, ABCI hooks, CLI registration.
+- **`client/cli/`** — CLI commands for transactions and queries.
+
+### App Wiring: `app/`
+
+- **`app.go`** — Full app construction with all Cosmos SDK and IBC modules wired together. The wasm keeper is configured here with its dependencies (bank, staking, IBC, etc.).
+- **`ante.go`** — Custom AnteHandler chain including wasm-specific decorators.
+- **`upgrades.go` / `upgrades/`** — Chain upgrade handlers.
+
+### Testing
+
+- **`x/wasm/keeper/test_common.go`** — Shared test setup for keeper tests; creates a full app context with all keepers.
+- **`x/wasm/keeper/wasmtesting/`** — Mock implementations for testing (mock keepers, messengers, query handlers).
+- **`x/wasm/keeper/testdata/`** — Pre-compiled `.wasm` contract binaries used in tests.
+- **`tests/e2e/`** — End-to-end tests.
+- **`tests/system/`** — System-level integration tests (run via `make test-system`).
+
+## Key Conventions
+
+- **Error wrapping**: Use `errorsmod.Wrap(err, "context")` (from `cosmossdk.io/errors`), not `fmt.Errorf`. This predates Go's `errors.Is` pattern.
+- **Import ordering** (enforced by `gci`): standard library, then `cosmossdk.io`, then `github.com/cosmos/cosmos-sdk`, then `github.com/CosmWasm/wasmd`, with blank line separators.
+- **Determinism**: All state-machine code must be deterministic. No floating point, no maps with non-deterministic iteration, no system time.
+- **Protobuf types**: Generated `.pb.go` files live alongside hand-written code in `x/wasm/types/`. Regenerate with `make proto-gen` (Docker required).
+- **Build tags**: Tests use `-tags='ledger test_ledger_mock'`. The `VERSION` env var is set during test runs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # docker build . -t cosmwasm/wasmd:latest
 # docker run --rm -it cosmwasm/wasmd:latest /bin/sh
 
-FROM golang:1.24-alpine AS go-builder
+FROM golang:1.25-alpine AS go-builder
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/CosmWasm/wasmvm/v3 v3.0.3
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
-	github.com/cosmos/cosmos-sdk v0.53.5
+	github.com/cosmos/cosmos-sdk v0.53.6
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/gogoproto v1.7.2
 	github.com/cosmos/iavl v1.2.6
@@ -97,7 +97,7 @@ require (
 	github.com/cometbft/cometbft-db v0.14.1 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
-	github.com/cosmos/ledger-cosmos-go v0.16.0 // indirect
+	github.com/cosmos/ledger-cosmos-go v1.0.0 // indirect
 	github.com/creachadair/atomicfile v0.3.1 // indirect
 	github.com/creachadair/tomledit v0.0.24 // indirect
 	github.com/danieljoos/wincred v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -80,8 +80,8 @@ require (
 	github.com/bgentry/speakeasy v0.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.3 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.2 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -822,8 +822,8 @@ github.com/cosmos/cosmos-db v1.1.3 h1:7QNT77+vkefostcKkhrzDK9uoIEryzFrU9eoMeaQOP
 github.com/cosmos/cosmos-db v1.1.3/go.mod h1:kN+wGsnwUJZYn8Sy5Q2O0vCYA99MJllkKASbs6Unb9U=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.53.5 h1:JPue+SFn2gyDzTV9TYb8mGpuIH3kGt7WbGadulkpTcU=
-github.com/cosmos/cosmos-sdk v0.53.5/go.mod h1:AQJx0jpon70WAD4oOs/y+SlST4u7VIwEPR6F8S7JMdo=
+github.com/cosmos/cosmos-sdk v0.53.6 h1:aJeInld7rbsHtH1qLHu2aZJF9t40mGlqp3ylBLDT0HI=
+github.com/cosmos/cosmos-sdk v0.53.6/go.mod h1:N6YuprhAabInbT3YGumGDKONbvPX5dNro7RjHvkQoKE=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=
@@ -839,8 +839,8 @@ github.com/cosmos/ics23/go v0.11.0 h1:jk5skjT0TqX5e5QJbEnwXIS2yI2vnmLOgpQPeM5Rtn
 github.com/cosmos/ics23/go v0.11.0/go.mod h1:A8OjxPE67hHST4Icw94hOxxFEJMBG031xIGF/JHNIY0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
 github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
-github.com/cosmos/ledger-cosmos-go v0.16.0 h1:YKlWPG9NnGZIEUb2bEfZ6zhON1CHlNTg0QKRRGcNEd0=
-github.com/cosmos/ledger-cosmos-go v0.16.0/go.mod h1:WrM2xEa8koYoH2DgeIuZXNarF7FGuZl3mrIOnp3Dp0o=
+github.com/cosmos/ledger-cosmos-go v1.0.0 h1:jNKW89nPf0vR0EkjHG8Zz16h6p3zqwYEOxlHArwgYtw=
+github.com/cosmos/ledger-cosmos-go v1.0.0/go.mod h1:mGaw2wDOf+Z6SfRJsMGxU9DIrBa4du0MAiPlpPhLAOE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creachadair/atomicfile v0.3.1 h1:yQORkHjSYySh/tv5th1dkKcn02NEW5JleB84sjt+W4Q=

--- a/go.sum
+++ b/go.sum
@@ -739,10 +739,10 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=

--- a/tests/integration/migrations_integration_test.go
+++ b/tests/integration/migrations_integration_test.go
@@ -49,7 +49,7 @@ func TestModuleMigrations(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			var expModuleVersion uint64 = 4
+			var expModuleVersion uint64 = 5
 			assert.Equal(t, expModuleVersion, gotVM[types.ModuleName])
 			gotParams := wasmApp.WasmKeeper.GetParams(ctx)
 			assert.Equal(t, spec.exp, gotParams)
@@ -93,7 +93,7 @@ func TestAccessConfigMigrations(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	var expModuleVersion uint64 = 4
+	var expModuleVersion uint64 = 5
 	assert.Equal(t, expModuleVersion, gotVM[types.ModuleName])
 
 	// any address was not migrated

--- a/tests/system/go.mod
+++ b/tests/system/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5 // indirect
-	github.com/cosmos/cosmos-sdk v0.53.5
+	github.com/cosmos/cosmos-sdk v0.53.6
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/gogoproto v1.7.2 // indirect
 	github.com/cosmos/iavl v1.2.2 // indirect
@@ -66,7 +66,7 @@ require (
 	github.com/cosmos/cosmos-db v1.1.3 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/ics23/go v0.11.0 // indirect
-	github.com/cosmos/ledger-cosmos-go v0.16.0 // indirect
+	github.com/cosmos/ledger-cosmos-go v1.0.0 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect

--- a/tests/system/go.mod
+++ b/tests/system/go.mod
@@ -50,8 +50,8 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.2.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.2 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect

--- a/tests/system/go.sum
+++ b/tests/system/go.sum
@@ -142,8 +142,8 @@ github.com/cosmos/cosmos-db v1.1.3 h1:7QNT77+vkefostcKkhrzDK9uoIEryzFrU9eoMeaQOP
 github.com/cosmos/cosmos-db v1.1.3/go.mod h1:kN+wGsnwUJZYn8Sy5Q2O0vCYA99MJllkKASbs6Unb9U=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.53.5 h1:JPue+SFn2gyDzTV9TYb8mGpuIH3kGt7WbGadulkpTcU=
-github.com/cosmos/cosmos-sdk v0.53.5/go.mod h1:AQJx0jpon70WAD4oOs/y+SlST4u7VIwEPR6F8S7JMdo=
+github.com/cosmos/cosmos-sdk v0.53.6 h1:aJeInld7rbsHtH1qLHu2aZJF9t40mGlqp3ylBLDT0HI=
+github.com/cosmos/cosmos-sdk v0.53.6/go.mod h1:N6YuprhAabInbT3YGumGDKONbvPX5dNro7RjHvkQoKE=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=
@@ -157,8 +157,8 @@ github.com/cosmos/ics23/go v0.11.0 h1:jk5skjT0TqX5e5QJbEnwXIS2yI2vnmLOgpQPeM5Rtn
 github.com/cosmos/ics23/go v0.11.0/go.mod h1:A8OjxPE67hHST4Icw94hOxxFEJMBG031xIGF/JHNIY0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
 github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
-github.com/cosmos/ledger-cosmos-go v0.16.0 h1:YKlWPG9NnGZIEUb2bEfZ6zhON1CHlNTg0QKRRGcNEd0=
-github.com/cosmos/ledger-cosmos-go v0.16.0/go.mod h1:WrM2xEa8koYoH2DgeIuZXNarF7FGuZl3mrIOnp3Dp0o=
+github.com/cosmos/ledger-cosmos-go v1.0.0 h1:jNKW89nPf0vR0EkjHG8Zz16h6p3zqwYEOxlHArwgYtw=
+github.com/cosmos/ledger-cosmos-go v1.0.0/go.mod h1:mGaw2wDOf+Z6SfRJsMGxU9DIrBa4du0MAiPlpPhLAOE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=

--- a/tests/system/go.sum
+++ b/tests/system/go.sum
@@ -79,10 +79,10 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=

--- a/x/wasm/migrations/v4_xion/legacy_types.go
+++ b/x/wasm/migrations/v4_xion/legacy_types.go
@@ -1,22 +1,35 @@
 package v4
 
 import (
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/gogoproto/proto"
 )
 
 // LegacyContractInfo represents the ContractInfo structure from wasmd v0.61.2
 // where ibc2_port_id was at field 7 and extension was at field 8.
 // This is the INCORRECT field order that was fixed in v0.61.5+ (commit 6cbaaae4).
+//
+// IMPORTANT: We use *LegacyAny instead of *codectypes.Any for the Extension field
+// because codectypes.Any has an unexported cachedValue field without a protobuf tag.
+// Since LegacyContractInfo is a hand-written type (no generated XXX_Unmarshal),
+// gogoproto falls back to its table-driven unmarshaler which panics on
+// "protobuf tag not enough fields in Any.cachedValue".
 type LegacyContractInfo struct {
-	CodeID      uint64                 `protobuf:"varint,1,opt,name=code_id,json=codeId,proto3" json:"code_id,omitempty"`
-	Creator     string                 `protobuf:"bytes,2,opt,name=creator,proto3" json:"creator,omitempty"`
-	Admin       string                 `protobuf:"bytes,3,opt,name=admin,proto3" json:"admin,omitempty"`
-	Label       string                 `protobuf:"bytes,4,opt,name=label,proto3" json:"label,omitempty"`
-	Created     *AbsoluteTxPosition    `protobuf:"bytes,5,opt,name=created,proto3" json:"created,omitempty"`
-	IBCPortID   string                 `protobuf:"bytes,6,opt,name=ibc_port_id,json=ibcPortId,proto3" json:"ibc_port_id,omitempty"`
-	IBC2PortID  string                 `protobuf:"bytes,7,opt,name=ibc2_port_id,json=ibc2PortId,proto3" json:"ibc2_port_id,omitempty"` // OLD: field 7
-	Extension   *codectypes.Any        `protobuf:"bytes,8,opt,name=extension,proto3" json:"extension,omitempty"`                        // OLD: field 8
+	CodeID     uint64              `protobuf:"varint,1,opt,name=code_id,json=codeId,proto3" json:"code_id,omitempty"`
+	Creator    string              `protobuf:"bytes,2,opt,name=creator,proto3" json:"creator,omitempty"`
+	Admin      string              `protobuf:"bytes,3,opt,name=admin,proto3" json:"admin,omitempty"`
+	Label      string              `protobuf:"bytes,4,opt,name=label,proto3" json:"label,omitempty"`
+	Created    *AbsoluteTxPosition `protobuf:"bytes,5,opt,name=created,proto3" json:"created,omitempty"`
+	IBCPortID  string              `protobuf:"bytes,6,opt,name=ibc_port_id,json=ibcPortId,proto3" json:"ibc_port_id,omitempty"`
+	IBC2PortID string              `protobuf:"bytes,7,opt,name=ibc2_port_id,json=ibc2PortId,proto3" json:"ibc2_port_id,omitempty"` // OLD: field 7
+	Extension  *LegacyAny          `protobuf:"bytes,8,opt,name=extension,proto3" json:"extension,omitempty"`                       // OLD: field 8
+}
+
+// LegacyAny is a minimal replacement for codectypes.Any that only contains
+// protobuf-tagged fields. This avoids the gogoproto table-driven unmarshaler
+// panic caused by codectypes.Any's unexported cachedValue field.
+type LegacyAny struct {
+	TypeUrl string `protobuf:"bytes,1,opt,name=type_url,json=typeUrl,proto3" json:"type_url,omitempty"`
+	Value   []byte `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 }
 
 // AbsoluteTxPosition is a unique transaction position that allows for global ordering of transactions.
@@ -28,6 +41,10 @@ type AbsoluteTxPosition struct {
 func (m *LegacyContractInfo) Reset()         { *m = LegacyContractInfo{} }
 func (m *LegacyContractInfo) String() string { return proto.CompactTextString(m) }
 func (*LegacyContractInfo) ProtoMessage()    {}
+
+func (m *LegacyAny) Reset()         { *m = LegacyAny{} }
+func (m *LegacyAny) String() string { return proto.CompactTextString(m) }
+func (*LegacyAny) ProtoMessage()    {}
 
 func (m *AbsoluteTxPosition) Reset()         { *m = AbsoluteTxPosition{} }
 func (m *AbsoluteTxPosition) String() string { return proto.CompactTextString(m) }

--- a/x/wasm/migrations/v4_xion/legacy_types_test.go
+++ b/x/wasm/migrations/v4_xion/legacy_types_test.go
@@ -1,0 +1,104 @@
+package v4
+
+import (
+	"testing"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLegacyContractInfoUnmarshalWithExtension verifies that unmarshaling a
+// LegacyContractInfo with a non-nil Extension field does NOT panic.
+//
+// This was the root cause of the v28 upgrade failure:
+// codectypes.Any has an unexported cachedValue field without a protobuf tag.
+// When gogoproto's table-driven unmarshaler encounters it, it panics with
+// "protobuf tag not enough fields in Any.cachedValue".
+//
+// The fix uses LegacyAny (which only has tagged fields) instead of codectypes.Any.
+func TestLegacyContractInfoUnmarshalWithExtension(t *testing.T) {
+	// Build a LegacyContractInfo with Extension populated (field 8 in legacy schema)
+	original := &LegacyContractInfo{
+		CodeID:     42,
+		Creator:    "xion1creator",
+		Admin:      "xion1admin",
+		Label:      "my-contract",
+		IBCPortID:  "wasm.xion1port",
+		IBC2PortID: "wasm.xion1ibc2port",
+		Created: &AbsoluteTxPosition{
+			BlockHeight: 100,
+			TxIndex:     5,
+		},
+		Extension: &LegacyAny{
+			TypeUrl: "/xion.v1.ContractExtension",
+			Value:   []byte{0x0a, 0x04, 0x74, 0x65, 0x73, 0x74}, // some protobuf bytes
+		},
+	}
+
+	// Marshal it
+	bz, err := proto.Marshal(original)
+	require.NoError(t, err)
+
+	// Unmarshal - this used to panic with codectypes.Any
+	var decoded LegacyContractInfo
+	assert.NotPanics(t, func() {
+		err = proto.Unmarshal(bz, &decoded)
+	}, "unmarshaling LegacyContractInfo with Extension should not panic")
+	require.NoError(t, err)
+
+	// Verify fields round-tripped correctly
+	assert.Equal(t, original.CodeID, decoded.CodeID)
+	assert.Equal(t, original.Creator, decoded.Creator)
+	assert.Equal(t, original.Admin, decoded.Admin)
+	assert.Equal(t, original.Label, decoded.Label)
+	assert.Equal(t, original.IBCPortID, decoded.IBCPortID)
+	assert.Equal(t, original.IBC2PortID, decoded.IBC2PortID)
+	assert.Equal(t, original.Created.BlockHeight, decoded.Created.BlockHeight)
+	assert.Equal(t, original.Created.TxIndex, decoded.Created.TxIndex)
+	require.NotNil(t, decoded.Extension)
+	assert.Equal(t, original.Extension.TypeUrl, decoded.Extension.TypeUrl)
+	assert.Equal(t, original.Extension.Value, decoded.Extension.Value)
+}
+
+// TestLegacyAnyToCodecTypesAny verifies conversion from LegacyAny to codectypes.Any.
+func TestLegacyAnyToCodecTypesAny(t *testing.T) {
+	legacy := &LegacyAny{
+		TypeUrl: "/xion.v1.SomeType",
+		Value:   []byte{0x01, 0x02, 0x03},
+	}
+
+	converted := &codectypes.Any{
+		TypeUrl: legacy.TypeUrl,
+		Value:   legacy.Value,
+	}
+
+	assert.Equal(t, legacy.TypeUrl, converted.TypeUrl)
+	assert.Equal(t, legacy.Value, converted.Value)
+}
+
+// TestLegacyContractInfoUnmarshalWithoutExtension verifies that contracts
+// without an Extension field still unmarshal correctly.
+func TestLegacyContractInfoUnmarshalWithoutExtension(t *testing.T) {
+	original := &LegacyContractInfo{
+		CodeID:     1,
+		Creator:    "xion1creator",
+		Label:      "simple-contract",
+		IBC2PortID: "",
+	}
+
+	bz, err := proto.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded LegacyContractInfo
+	assert.NotPanics(t, func() {
+		err = proto.Unmarshal(bz, &decoded)
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, original.CodeID, decoded.CodeID)
+	assert.Equal(t, original.Creator, decoded.Creator)
+	assert.Equal(t, original.Label, decoded.Label)
+	assert.Nil(t, decoded.Extension)
+}

--- a/x/wasm/migrations/v4_xion/store.go
+++ b/x/wasm/migrations/v4_xion/store.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/store/prefix"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -85,7 +86,10 @@ func (m Migrator) Migrate4to5(ctx sdk.Context, storeService corestoretypes.KVSto
 
 		// Copy Extension field - moved from field 8 to field 7
 		if legacyInfo.Extension != nil {
-			newInfo.Extension = legacyInfo.Extension
+			newInfo.Extension = &codectypes.Any{
+				TypeUrl: legacyInfo.Extension.TypeUrl,
+				Value:   legacyInfo.Extension.Value,
+			}
 		}
 
 		// Store with NEW schema


### PR DESCRIPTION
This pull request addresses a critical issue with protobuf unmarshaling of legacy contract data in the `x/wasm/migrations/v4_xion` package, which previously led to upgrade failures. The main fix replaces the use of `codectypes.Any` with a custom `LegacyAny` type in legacy contract structures, preventing panics during migration. The PR also updates related migration logic and adds comprehensive tests to ensure robust handling of legacy data. Additionally, the pull request updates GitHub Actions workflow files to use a consistent version of the `actions/checkout` action.

**Legacy contract migration and protobuf compatibility:**

* Replaces the `Extension` field in `LegacyContractInfo` with a custom `LegacyAny` type (instead of `codectypes.Any`) to avoid panics caused by unexported fields during protobuf unmarshaling. This change is fully documented in code comments. (`x/wasm/migrations/v4_xion/legacy_types.go`) [[1]](diffhunk://#diff-a5d3cff4fb21b9a11a825863a24aeb4b17da732557002c59d6a75ad50358c89eL4-R15) [[2]](diffhunk://#diff-a5d3cff4fb21b9a11a825863a24aeb4b17da732557002c59d6a75ad50358c89eL19-R32)
* Implements the `LegacyAny` type and associated protobuf methods to ensure compatibility with gogoproto's unmarshaler. (`x/wasm/migrations/v4_xion/legacy_types.go`) [[1]](diffhunk://#diff-a5d3cff4fb21b9a11a825863a24aeb4b17da732557002c59d6a75ad50358c89eL19-R32) [[2]](diffhunk://#diff-a5d3cff4fb21b9a11a825863a24aeb4b17da732557002c59d6a75ad50358c89eR45-R48)
* Updates the migration logic to convert from `LegacyAny` to `codectypes.Any` when migrating data to the new schema. (`x/wasm/migrations/v4_xion/store.go`) [[1]](diffhunk://#diff-fa6ad5bb46492da7fa388718eb6b53df0564050120938c497c270cc33b22f9d6R10) [[2]](diffhunk://#diff-fa6ad5bb46492da7fa388718eb6b53df0564050120938c497c270cc33b22f9d6L88-R92)
* Adds thorough tests covering marshaling and unmarshaling of legacy contracts with and without the `Extension` field, and tests conversion between `LegacyAny` and `codectypes.Any`. (`x/wasm/migrations/v4_xion/legacy_types_test.go`)

**CI/CD workflow maintenance:**

* Updates all GitHub Actions workflow files to use `actions/checkout@v5` instead of `@v6` for consistency and compatibility. (`.github/workflows/checks.yml`, `.github/workflows/codeql-analizer.yml`, `.github/workflows/proto-buf-linter.yml`, `.github/workflows/proto-buf-publisher.yml`, `.github/workflows/release.yml`, `.github/workflows/staticmajor.yml`, `.github/workflows/typo-check.yml`) [[1]](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L16-R16) [[2]](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L44-R44) [[3]](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L54-R54) [[4]](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L68-R68) [[5]](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L101-R101) [[6]](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L120-R120) [[7]](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L152-R152) [[8]](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L174-R174) [[9]](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L185-R185) [[10]](diffhunk://#diff-0e027f0d38f2f6940f833134a5b4b116b69bb0891c268004913058187437076dL22-R22) [[11]](diffhunk://#diff-2a6f908f6a53b61d15673d4085976a6686158500b105f86ee84fa88700bc8893L16-R16) [[12]](diffhunk://#diff-5625d1e94a007c22a5218a4ee6d4ff92e362db468601199993402956a19b5423L19-R19) [[13]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L19-R19) [[14]](diffhunk://#diff-b89d1de0c38230d836ffc60e0540036b75a7c8ede1abeca487f4d0a6f16b9e61L17-R17) [[15]](diffhunk://#diff-14f0d609fe4cb5c20cabb5fc5f5ce6b26a2540ff35dfa1093310d447a41fa952L17-R17)

These changes collectively ensure that legacy contract migrations are robust and that CI workflows remain up-to-date and reliable.