### PR TITLE
feat(wasm): support keeper-defined Instantiate2 address hash

### DIFF
--- a/x/wasm/alias.go
+++ b/x/wasm/alias.go
@@ -28,6 +28,7 @@ const (
 
 var (
 	// functions aliases
+	//
 	// Deprecated: Do not use.
 	RegisterCodec = types.RegisterLegacyAminoCodec
 	// Deprecated: Do not use.
@@ -96,6 +97,7 @@ var (
 	NewCountTXDecorator = keeper.NewCountTXDecorator
 
 	// variable aliases
+	//
 	// Deprecated: Do not use.
 	DefaultCodespace = types.DefaultCodespace
 	// Deprecated: Do not use.

--- a/x/wasm/keeper/contract_keeper.go
+++ b/x/wasm/keeper/contract_keeper.go
@@ -8,7 +8,10 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 )
 
-var _ types.ContractOpsKeeper = PermissionedKeeper{}
+var (
+	_ types.ContractOpsKeeper                = PermissionedKeeper{}
+	_ types.ContractOpsKeeperWithAddressHash = PermissionedKeeper{}
+)
 
 // decoratedKeeper contains a subset of the wasm keeper that are already or can be guarded by an authorization policy in the future
 type decoratedKeeper interface {
@@ -89,6 +92,43 @@ func (p PermissionedKeeper) Instantiate2(
 		label,
 		deposit,
 		PredictableAddressGenerator(creator, salt, initMsg, fixMsg),
+		p.authZPolicy,
+	)
+}
+
+// Instantiate2WithAddressHash creates an instance of a Wasm contract using a
+// caller-provided 32-byte hash for predictable address derivation. The
+// instantiated code ID and its checksum still control code loading,
+// permissions, execution, gas, capabilities, history, and ContractInfo. Only
+// the address namespace is replaced.
+//
+// This is a keeper-only capability for trusted modules. Public Wasm messages
+// continue to use Instantiate2 and the instantiated code's checksum.
+func (p PermissionedKeeper) Instantiate2WithAddressHash(
+	ctx sdk.Context,
+	codeID uint64,
+	addressHash []byte,
+	creator, admin sdk.AccAddress,
+	initMsg []byte,
+	label string,
+	deposit sdk.Coins,
+	salt []byte,
+) (sdk.AccAddress, []byte, error) {
+	if len(addressHash) != types.ContractAddrLen {
+		return nil, nil, types.ErrInvalid.Wrapf("address hash must be %d bytes", types.ContractAddrLen)
+	}
+
+	return p.nested.instantiate(
+		ctx,
+		codeID,
+		creator,
+		admin,
+		initMsg,
+		label,
+		deposit,
+		func(_ context.Context, _ uint64, _ []byte) sdk.AccAddress {
+			return BuildContractAddressPredictable(addressHash, creator, salt, nil)
+		},
 		p.authZPolicy,
 	)
 }

--- a/x/wasm/keeper/contract_keeper.go
+++ b/x/wasm/keeper/contract_keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"crypto/sha256"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -10,7 +11,7 @@ import (
 
 var (
 	_ types.ContractOpsKeeper                = PermissionedKeeper{}
-	_ types.ContractOpsKeeperWithAddressHash = PermissionedKeeper{}
+	_ types.ContractOpsKeeperWithAddressHash = AddressHashPermissionedKeeper{}
 )
 
 // decoratedKeeper contains a subset of the wasm keeper that are already or can be guarded by an authorization policy in the future
@@ -54,6 +55,31 @@ func NewGovPermissionKeeper(nested decoratedKeeper) *PermissionedKeeper {
 
 func NewDefaultPermissionKeeper(nested decoratedKeeper) *PermissionedKeeper {
 	return NewPermissionedKeeper(nested, DefaultAuthorizationPolicy{})
+}
+
+// AddressHashPermissionedKeeper is an explicitly granted extension of
+// PermissionedKeeper. Keeping the method on a distinct dynamic type prevents
+// modules that receive an ordinary ContractOpsKeeper from type-asserting into
+// the address-hash capability.
+type AddressHashPermissionedKeeper struct {
+	PermissionedKeeper
+}
+
+func NewAddressHashPermissionedKeeper(
+	nested decoratedKeeper,
+	authZPolicy types.AuthorizationPolicy,
+) *AddressHashPermissionedKeeper {
+	return &AddressHashPermissionedKeeper{
+		PermissionedKeeper: *NewPermissionedKeeper(nested, authZPolicy),
+	}
+}
+
+func NewGovPermissionKeeperWithAddressHash(nested decoratedKeeper) *AddressHashPermissionedKeeper {
+	return NewAddressHashPermissionedKeeper(nested, GovAuthorizationPolicy{})
+}
+
+func NewDefaultPermissionKeeperWithAddressHash(nested decoratedKeeper) *AddressHashPermissionedKeeper {
+	return NewAddressHashPermissionedKeeper(nested, DefaultAuthorizationPolicy{})
 }
 
 func (p PermissionedKeeper) Create(ctx sdk.Context, creator sdk.AccAddress, wasmCode []byte, instantiateAccess *types.AccessConfig) (codeID uint64, checksum []byte, err error) {
@@ -104,7 +130,7 @@ func (p PermissionedKeeper) Instantiate2(
 //
 // This is a keeper-only capability for trusted modules. Public Wasm messages
 // continue to use Instantiate2 and the instantiated code's checksum.
-func (p PermissionedKeeper) Instantiate2WithAddressHash(
+func (p AddressHashPermissionedKeeper) Instantiate2WithAddressHash(
 	ctx sdk.Context,
 	codeID uint64,
 	addressHash []byte,
@@ -114,8 +140,8 @@ func (p PermissionedKeeper) Instantiate2WithAddressHash(
 	deposit sdk.Coins,
 	salt []byte,
 ) (sdk.AccAddress, []byte, error) {
-	if len(addressHash) != types.ContractAddrLen {
-		return nil, nil, types.ErrInvalid.Wrapf("address hash must be %d bytes", types.ContractAddrLen)
+	if len(addressHash) != sha256.Size {
+		return nil, nil, types.ErrInvalid.Wrapf("address hash must be %d bytes", sha256.Size)
 	}
 
 	return p.nested.instantiate(

--- a/x/wasm/keeper/contract_keeper_test.go
+++ b/x/wasm/keeper/contract_keeper_test.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -170,6 +171,73 @@ func TestInstantiate2(t *testing.T) {
 			assert.NotEmpty(t, gotAddr)
 		})
 	}
+}
+
+func TestInstantiate2WithAddressHash(t *testing.T) {
+	parentCtx, keepers := CreateTestInput(t, false, AvailableCapabilities)
+	parentCtx = parentCtx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+
+	hackatom := StoreHackatomExampleContract(t, parentCtx, keepers)
+	reflect := StoreReflectContract(t, parentCtx, keepers)
+	contractKeeper := NewDefaultPermissionKeeper(keepers.WasmKeeper)
+	addressHash := bytes.Repeat([]byte{0xA5}, types.ContractAddrLen)
+	salt := []byte("module-owned-address")
+	expected := BuildContractAddressPredictable(addressHash, hackatom.CreatorAddr, salt, nil)
+
+	tests := []struct {
+		name    string
+		codeID  uint64
+		initMsg []byte
+	}{
+		{
+			name:   "hackatom implementation",
+			codeID: hackatom.CodeID,
+			initMsg: mustMarshal(t, HackatomExampleInitMsg{
+				Verifier:    RandomAccountAddress(t),
+				Beneficiary: RandomAccountAddress(t),
+			}),
+		},
+		{
+			name:    "reflect implementation",
+			codeID:  reflect.CodeID,
+			initMsg: []byte(`{}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, _ := parentCtx.CacheContext()
+			got, _, err := contractKeeper.Instantiate2WithAddressHash(
+				ctx,
+				tc.codeID,
+				addressHash,
+				hackatom.CreatorAddr,
+				nil,
+				tc.initMsg,
+				"fixed address hash",
+				nil,
+				salt,
+			)
+			require.NoError(t, err)
+			require.Equal(t, expected, got)
+			require.Equal(t, tc.codeID, keepers.WasmKeeper.GetContractInfo(ctx, got).CodeID)
+		})
+	}
+
+	t.Run("rejects an invalid address hash", func(t *testing.T) {
+		_, _, err := contractKeeper.Instantiate2WithAddressHash(
+			parentCtx,
+			hackatom.CodeID,
+			addressHash[:len(addressHash)-1],
+			hackatom.CreatorAddr,
+			nil,
+			[]byte(`{}`),
+			"invalid address hash",
+			nil,
+			salt,
+		)
+		require.ErrorIs(t, err, types.ErrInvalid)
+	})
 }
 
 func TestQuerierError(t *testing.T) {

--- a/x/wasm/keeper/contract_keeper_test.go
+++ b/x/wasm/keeper/contract_keeper_test.go
@@ -179,8 +179,8 @@ func TestInstantiate2WithAddressHash(t *testing.T) {
 
 	hackatom := StoreHackatomExampleContract(t, parentCtx, keepers)
 	reflect := StoreReflectContract(t, parentCtx, keepers)
-	contractKeeper := NewDefaultPermissionKeeper(keepers.WasmKeeper)
-	addressHash := bytes.Repeat([]byte{0xA5}, types.ContractAddrLen)
+	contractKeeper := NewDefaultPermissionKeeperWithAddressHash(keepers.WasmKeeper)
+	addressHash := bytes.Repeat([]byte{0xA5}, 32)
 	salt := []byte("module-owned-address")
 	expected := BuildContractAddressPredictable(addressHash, hackatom.CreatorAddr, salt, nil)
 
@@ -237,6 +237,12 @@ func TestInstantiate2WithAddressHash(t *testing.T) {
 			salt,
 		)
 		require.ErrorIs(t, err, types.ErrInvalid)
+	})
+
+	t.Run("ordinary permissioned keepers do not expose the capability", func(t *testing.T) {
+		ordinaryKeeper := NewDefaultPermissionKeeper(keepers.WasmKeeper)
+		_, ok := any(ordinaryKeeper).(types.ContractOpsKeeperWithAddressHash)
+		require.False(t, ok)
 	})
 }
 

--- a/x/wasm/keeper/handler_plugin.go
+++ b/x/wasm/keeper/handler_plugin.go
@@ -87,7 +87,7 @@ func (h SDKMessageHandler) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddr
 		}
 		events = append(events, sdkEvents...)
 	}
-	return
+	return events, data, msgResponses, err
 }
 
 func (h SDKMessageHandler) handleSdkMessage(ctx sdk.Context, contractAddr sdk.Address, msg sdk.Msg) (*sdk.Result, error) {

--- a/x/wasm/keeper/xion_exports.go
+++ b/x/wasm/keeper/xion_exports.go
@@ -3,8 +3,9 @@ package keeper
 import (
 	"context"
 
-	"github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm/types"
 )
 
 func (k Keeper) ImportCode(ctx context.Context, codeID uint64, codeInfo types.CodeInfo, wasmCode []byte) error {
@@ -21,11 +22,11 @@ func (k Keeper) ImportAutoIncrementID(ctx context.Context, sequenceKey []byte, v
 
 // appendToContractHistoryGenesis is a helper function to append to the contract history for genesis.
 // it skips creating iterators and assumes the contract history is already sorted
-// position starts from 0
+// Contract history positions start at 1, matching appendToContractHistory.
 func (k Keeper) appendToContractHistoryGenesis(ctx context.Context, contractAddr sdk.AccAddress, newEntries ...types.ContractCodeHistoryEntry) error {
 	store := k.storeService.OpenKVStore(ctx)
 	for pos, e := range newEntries {
-		key := types.GetContractCodeHistoryElementKey(contractAddr, uint64(pos))
+		key := types.GetContractCodeHistoryElementKey(contractAddr, uint64(pos)+1)
 		if err := store.Set(key, k.cdc.MustMarshal(&e)); err != nil {
 			return err
 		}

--- a/x/wasm/migrations/v2/legacy_types.go
+++ b/x/wasm/migrations/v2/legacy_types.go
@@ -19,6 +19,7 @@ const (
 	// AccessTypeNobody forbidden
 	AccessTypeNobody AccessType = 1
 	// AccessTypeOnlyAddress restricted to a single address
+	//
 	// Deprecated: use AccessTypeAnyOfAddresses instead
 	AccessTypeOnlyAddress AccessType = 2
 	// AccessTypeEverybody unrestricted
@@ -94,6 +95,7 @@ var xxx_messageInfo_AccessTypeParam proto.InternalMessageInfo
 type AccessConfig struct {
 	Permission AccessType `protobuf:"varint,1,opt,name=permission,proto3,enum=cosmwasm.wasm.v1.AccessType" json:"permission,omitempty" yaml:"permission"`
 	// Address
+	//
 	// Deprecated: replaced by addresses
 	Address   string   `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty" yaml:"address"`
 	Addresses []string `protobuf:"bytes,3,rep,name=addresses,proto3" json:"addresses,omitempty" yaml:"addresses"`

--- a/x/wasm/migrations/v3/legacy_types.go
+++ b/x/wasm/migrations/v3/legacy_types.go
@@ -20,6 +20,7 @@ const (
 	// AccessTypeNobody forbidden
 	AccessTypeNobody AccessType = 1
 	// AccessTypeOnlyAddress restricted to a single address
+	//
 	// Deprecated: use AccessTypeAnyOfAddresses instead
 	AccessTypeOnlyAddress AccessType = 2
 	// AccessTypeEverybody unrestricted
@@ -95,6 +96,7 @@ var xxx_messageInfo_AccessTypeParam proto.InternalMessageInfo
 type AccessConfig struct {
 	Permission AccessType `protobuf:"varint,1,opt,name=permission,proto3,enum=cosmwasm.wasm.v1.AccessType" json:"permission,omitempty" yaml:"permission"`
 	// Address
+	//
 	// Deprecated: replaced by addresses
 	Address   string   `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty" yaml:"address"`
 	Addresses []string `protobuf:"bytes,3,rep,name=addresses,proto3" json:"addresses,omitempty" yaml:"addresses"`

--- a/x/wasm/types/exported_keepers.go
+++ b/x/wasm/types/exported_keepers.go
@@ -85,6 +85,26 @@ type ContractOpsKeeper interface {
 	SetAccessConfig(ctx sdk.Context, codeID uint64, caller sdk.AccAddress, newConfig AccessConfig) error
 }
 
+// ContractOpsKeeperWithAddressHash extends ContractOpsKeeper with a
+// keeper-only predictable instantiation method whose address namespace is
+// independent of the instantiated code checksum. Chains should expose this
+// capability only to trusted modules that own a deterministic address
+// namespace; it is intentionally not part of the public Wasm message service.
+type ContractOpsKeeperWithAddressHash interface {
+	ContractOpsKeeper
+
+	Instantiate2WithAddressHash(
+		ctx sdk.Context,
+		codeID uint64,
+		addressHash []byte,
+		creator, admin sdk.AccAddress,
+		initMsg []byte,
+		label string,
+		deposit sdk.Coins,
+		salt []byte,
+	) (sdk.AccAddress, []byte, error)
+}
+
 // IBCContractKeeper IBC lifecycle event handler
 type IBCContractKeeper interface {
 	OnOpenChannel(

--- a/x/wasm/types/proposal_legacy.go
+++ b/x/wasm/types/proposal_legacy.go
@@ -32,10 +32,12 @@ const (
 )
 
 // DisableAllProposals contains no wasm gov types.
+//
 // Deprecated: all gov v1beta1 types will be removed
 var DisableAllProposals []ProposalType
 
 // EnableAllProposals contains all wasm gov types as keys.
+//
 // Deprecated: all gov v1beta1 types will be removed
 var EnableAllProposals = []ProposalType{
 	ProposalTypeStoreCode,


### PR DESCRIPTION
## Summary

- add a keeper-only `ContractOpsKeeperWithAddressHash` extension
- instantiate the requested Wasm code directly while deriving its predictable address from an explicit 32-byte hash
- preserve the existing authorization policy, instantiation pipeline, storage, events, and public `MsgInstantiateContract2` behavior
- keep the privileged capability on a distinct dynamic keeper type so ordinary `ContractOpsKeeper` consumers cannot recover it through a type assertion

The PR now targets the rebased `xion/main`, which is a direct descendant of upstream Wasmd v0.61.14.

## Security properties

- the extension is exposed through a distinct dynamic keeper type
- the authorization policy supplied to the permissioned keeper is preserved
- the requested code ID remains the code that is instantiated
- only the address checksum input is replaced
- invalid address hashes fail before state changes
- the normal public `Instantiate2` path is unchanged

## Verification

- `GOTOOLCHAIN=go1.24.1 go mod tidy` leaves `go.mod` and `go.sum` unchanged
- `GOTOOLCHAIN=go1.24.1 go test ./x/wasm/keeper -run 'TestInstantiate2(WithAddressHash)?$' -count=1`
- `git diff --check origin/xion/main..HEAD`
- Xion PR #581 compiles against the resulting tree: `go test ./app -run '^$'` and `go test ./x/xion/client/cli -run '^$'` with Go 1.25.8

The broader `go test ./x/wasm/keeper/... -count=1` run still reaches the Xion-specific `TestGenesisExportImport` instance-sequence assertion failure. The same failure reproduces on the equivalent Xion baseline before the feature commits, so it is not introduced by this PR.
